### PR TITLE
Initial commit of the ShardedRedisConnection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,3 +23,5 @@ deploy:
   user: sprockets
   password:
     secure: [REPLACE-ME]
+services:
+  - redis-server

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,13 @@
-%YAML 1.1
+%YAML 1.2
 ---
 language: python
 python:
-  - 2.6
   - 2.7
   - pypy
   - 3.2
   - 3.3
   - 3.4
 install:
-  - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install unittest2; fi
   - pip install -r test-requirements.txt
   - pip install -e .
 script: nosetests

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,15 @@
 sprockets.clients.redis
 =======================
-Base functionality for accessing/modifying data in Redis
+Base functionality for accessing/modifying data in Redis.  Currently
+there is only support for interacting with Redis servers in a sharded
+manner.
+
+That is to say, there are multiple Redis servers we are distributing reads
+and writes among them based on a consistent hash of the key value we're
+operating on.  This is also known as "Client Side Partitioning".
+
+More information about setting up or managing Redis in this manner
+can be found on the Redis documentation website: http://redis.io/topics/partitioning
 
 |Version| |Downloads| |Status| |Coverage| |License|
 
@@ -24,12 +33,21 @@ Requirements
 
 Example
 -------
-This examples demonstrates how to use ``sprockets.clients.redis`` by ...
+This examples demonstrates how to use a sharded Redis connection
+in ``sprockets.clients.redis`` by ...
 .. code:: python
 
+    import os
     from sprockets import clients.redis
 
-    # Example here
+    os.environ['REDIS_URI'] = 'redis://localhost/'
+
+    shard = clients.redis.ShardedRedisConnection()
+
+    shard.set('foo', 1)
+    value = shard.get('foo')
+    shard.delete('foo')
+
 
 Version History
 ---------------

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -4,7 +4,11 @@ The following example ...
 
 .. code:: python
 
-    from sprockets import clients.redis
+    import os
+    os.environ['REDIS_URI'] = 'redis://localhost/'
 
-    class Foo(object):
-        pass
+    shard = ShardedRedisConnection()
+
+    shard.set('foo', 1)
+    value = shard.get('foo')
+    shard.delete('foo')

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -1,5 +1,9 @@
-Version History
----------------
-- 0.0.0 [YYYY-MM-DD]
- - Change 1
- - Change 2
+.. :changelog:
+
+Release History
+===============
+
+Next Release
+------------
+
+* Initial release of the sharded redis connection.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+consistent_hash==1.0
+hiredis==0.1.6
+redis==2.10.3

--- a/setup.py
+++ b/setup.py
@@ -22,10 +22,6 @@ install_requires = read_requirements_file('requirements.txt')
 setup_requires = read_requirements_file('setup-requirements.txt')
 tests_require = read_requirements_file('test-requirements.txt')
 
-if sys.version_info < (2, 7):
-    tests_require.append('unittest2')
-if sys.version_info < (3, 0):
-    tests_require.append('mock')
 
 setuptools.setup(
     name='sprockets.clients.redis',
@@ -43,7 +39,6 @@ setuptools.setup(
         'Natural Language :: English',
         'Operating System :: OS Independent',
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.2',

--- a/sprockets/clients/redis/__init__.py
+++ b/sprockets/clients/redis/__init__.py
@@ -1,8 +1,139 @@
 """
 clients.redis
+=============
 
-Base functionality for accessing/modifying data in Redis
+Base functionality for accessing/modifying data in Redis.  Currently
+the supported functionality is accessing Redis in a sharded manner.
 
 """
-version_info = (0, 0, 0)
+import collections
+import logging
+import os
+import socket
+
+from consistent_hash import ConsistentHash
+import redis
+
+try:
+    from urllib.parse import parse_qs, urlsplit
+except ImportError:
+    from urlparse import parse_qs, urlsplit
+
+version_info = (1, 0, 0)
 __version__ = '.'.join(str(v) for v in version_info)
+
+LOGGER = logging.getLogger(__name__)
+
+DEFAULT_TTL = 24 * 60 * 60  # One day
+DEFAULT_PORT = '6379'
+
+_redis_config = collections.namedtuple('config', 'hosts port db ttl')
+"""Container object for holding the exploded URI"""
+
+
+class ShardedRedisConnection(object):
+    """Maintain a list of several Redis backends in a sharded manner.
+
+    This class establishes several pools based off of the IP addresses
+    resolved from the ``hostname`` part of the ``REDIS_URI`` environment
+    variable.  Any reads, writes, or deletes will be delegated to the proper
+    Redis backend by determining which shard the query should be directed
+    to.
+
+    Additionally, the ``info`` method is available to gather health
+    information across all of the servers in the backend.  This data can
+    be used to determine the health of the service.
+
+    .. note::
+
+        The hostname in the ``REDIS_URI`` will be DNS resolved and a
+        connection will be opened for each address returned in the
+        answer section.  You can specify a Round-Robin DNS record and
+        we will open a connection to all hosts returned.
+
+    """
+
+    def __init__(self):
+        self.config = self._get_redis_config()
+        self._connections = {}
+        self._consistent_hash = ConsistentHash(self.config.hosts)
+        self._establish_connections(self.config)
+
+    def _get_redis_config(self):
+        """Construct a Redis config object from the URI env-var."""
+        LOGGER.debug(
+            'Creating connection info for "%s"', os.environ['REDIS_URI'])
+
+        broken = urlsplit(os.environ['REDIS_URI'])
+
+        if broken.scheme != 'redis':
+            raise RuntimeError('Non "redis://" URI provided in REDIS_URI!')
+
+        _, _, ip_addresses = socket.gethostbyname_ex(broken.hostname)
+
+        if not ip_addresses:
+            raise RuntimeError('Unable to find Redis in DNS!')
+
+        ttl = DEFAULT_TTL
+        if broken.query:
+            # parse_qs returns a list of values given a key
+            ttl = parse_qs(broken.query).get('ttl', [ttl])[0]
+
+        return _redis_config(
+            hosts=ip_addresses,
+            port=broken.port or DEFAULT_PORT,
+            db=broken.path[1:],  # Remove the leading /
+            ttl=int(ttl),
+        )
+
+    def _establish_connections(self, config):
+        """Create Redis connection pool objects for each server shard."""
+        LOGGER.debug('Establishing Redis connection pools')
+        for host in config.hosts:
+            LOGGER.debug('Opening Redis connection to host "%s"', host)
+            self._connections[host] = redis.StrictRedis(
+                host=host,
+                port=config.port,
+                db=config.db,
+            )
+
+    def _get_shard_connection(self, key):
+        """Get a connection for a Redis shard given a ``key``."""
+        LOGGER.debug('Getting Redis host shard given key "%s"', key)
+        host = self._consistent_hash.get_node(key)
+        LOGGER.debug('Got Redis host shard "%s" given key "%s"', host, key)
+        return self._connections[host]
+
+    def set(self, key, value, ttl=None):
+        """Set ``key`` to ``value`` in a Redis shard."""
+        LOGGER.debug('Setting Redis key "%s" to "%s"', key, value)
+        ttl = ttl or self.config.ttl
+        connection = self._get_shard_connection(key)
+        connection.set(key, value, ex=ttl)
+
+    def get(self, key):
+        """Get a ``key`` in a Redis shard."""
+        LOGGER.debug('Getting Redis value given key "%s"', key)
+        connection = self._get_shard_connection(key)
+        return connection.get(key)
+
+    def delete(self, key):
+        """Delete a ``key`` in a Redis shard."""
+        LOGGER.debug('Deleting Redis key "%s"', key)
+        connection = self._get_shard_connection(key)
+        connection.delete(key)
+
+    def info(self):
+        """Return a list of the health of each connected redis server.
+
+        :rtype: list
+        :returns: A list of the server info from all of the server shards.
+
+        """
+        LOGGER.info('Getting Redis server stats')
+        stats = []
+        for host, connection in self._connections.items():
+            LOGGER.debug('Getting Redis health for host "%s"', host)
+            stats.append(connection.info())
+
+        return stats

--- a/tests.py
+++ b/tests.py
@@ -2,12 +2,62 @@
 Tests for the sprockets.clients.redis package
 
 """
-import mock
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import os
+import time
+import unittest
+import uuid
+
+from sprockets.clients.redis import ShardedRedisConnection
 
 
-class MyTest(unittest.TestCase):
-    pass
+class TestShardedRedisConnectionClass(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestShardedRedisConnectionClass, cls).setUpClass()
+        cls._old_environ = os.environ.get('REDIS_URI', '')
+        os.environ['REDIS_URI'] = 'redis://localhost?ttl=10'
+        cls.conn = ShardedRedisConnection()
+
+    @classmethod
+    def tearDownClass(cls):
+        super(TestShardedRedisConnectionClass, cls).tearDownClass()
+        os.environ['REDIS_URI'] = cls._old_environ
+
+    def setUp(self):
+        self.key = uuid.uuid4().hex
+        self.value = uuid.uuid4().hex
+        super(TestShardedRedisConnectionClass, self).setUp()
+
+    def test_saving_a_new_key(self):
+        self.conn.set(self.key, self.value)
+        self.assertEqual(self.conn.get(self.key), self.value)
+
+    def test_deleting_a_key(self):
+        self.conn.set(self.key, self.value)
+        self.conn.delete(self.key)
+        self.assertIsNone(self.conn.get(self.key))
+
+    def test_expiring_a_key(self):
+        self.conn.set(self.key, self.value, ttl=1)
+        time.sleep(2)
+        self.assertIsNone(self.conn.get(self.key))
+
+    def test_getting_health_info(self):
+        self.assertIsNotNone(self.conn.info())
+
+    def test_bad_redis_uri(self):
+        old = os.environ['REDIS_URI']
+        os.environ['REDIS_URI'] = 'http://example.com'
+        with self.assertRaises(Exception):
+            ShardedRedisConnection()
+
+        os.environ['REDIS_URI'] = old
+
+    def test_bad_redis_hosts(self):
+        old = os.environ['REDIS_URI']
+        os.environ['REDIS_URI'] = 'redis://gooblegobble.foo.bar'
+        with self.assertRaises(Exception):
+            ShardedRedisConnection()
+
+        os.environ['REDIS_URI'] = old


### PR DESCRIPTION
This PR adds a new class called `ShardedRedisConnection` that will connect to multiple Redis backends in a sharded manner.  We're making use of the `consistent_hash` library to distribute reads and writes to the various shards given the hash results of the `key` value you're getting or modifying.

The connection will do a DNS query, and if there are multiple A records associated with the hostname section of the `REDIS_URI`, we will open and maintain connections to all of the resolved hosts.
