### PR TITLE
Drop python 3 support for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ language: python
 python:
   - 2.7
   - pypy
-  - 3.2
-  - 3.3
-  - 3.4
+  # - 3.2 # Depends on consistent_hash supporting python 3 https://github.com/yummybian/consistent-hash/issues/8
+  # - 3.3
+  # - 3.4
 install:
   - pip install -r test-requirements.txt
   - pip install -e .


### PR DESCRIPTION
A nice little library that we're using here doesn't support Python 3 just yet.  There was work done on it but it just needs to be released.

https://github.com/yummybian/consistent-hash/issues/8

Once there is a package out with Python 3 support this commit will be reverted.
