### PR TITLE
Fix log issue

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -6,10 +6,17 @@ Release History
 Next Release
 ------------
 
+`1.0.1`_ (2015-04-30)
+---------------------
+
+* Don't log the payload in the DEBUG level logs, causes an encoding error when it's not ascii
+
+
 `1.0.0`_ (2015-03-30)
 ---------------------
 
 * Initial release of the sharded redis connection.
 
 
+.. _`1.0.1`: https://github.com/sprockets/sprockets.clients.redis/compare/1.0.0...1.0.1
 .. _`1.0.0`: https://github.com/sprockets/sprockets.clients.redis/compare/0.0.0...1.0.0

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ tests_require = read_requirements_file('test-requirements.txt')
 
 setuptools.setup(
     name='sprockets.clients.redis',
-    version='1.0.0',
+    version='1.0.1',
     description='Base functionality for accessing/modifying data in Redis',
     long_description=codecs.open('README.rst', encoding='utf-8').read(),
     url='https://github.com/sprockets/sprockets.clients.redis.git',

--- a/sprockets/clients/redis/__init__.py
+++ b/sprockets/clients/redis/__init__.py
@@ -106,7 +106,7 @@ class ShardedRedisConnection(object):
 
     def set(self, key, value, ttl=None):
         """Set ``key`` to ``value`` in a Redis shard."""
-        LOGGER.debug('Setting Redis key "%s" to "%s"', key, value)
+        LOGGER.debug('Setting Redis key "%s"', key)
         ttl = ttl or self.config.ttl
         connection = self._get_shard_connection(key)
         connection.set(key, value, ex=ttl)


### PR DESCRIPTION
Don't log the value in the DEBUG level, causes the application logger to blow up due to unknown encodings when dealing with binary data.
